### PR TITLE
Show fix of CustomWebFilterTest

### DIFF
--- a/src/main/java/de/rememberbrall/CustomWebFilter.java
+++ b/src/main/java/de/rememberbrall/CustomWebFilter.java
@@ -16,8 +16,7 @@ public class CustomWebFilter implements WebFilter {
         if (exchange.getRequest().getURI().getPath().equals("/")) {
             ServerHttpRequest mutatedHttpRequest = exchange.getRequest().mutate().path("/docs/index.html").build();
             ServerWebExchange serverWebExchange = exchange.mutate().request(mutatedHttpRequest).build();
-            Mono<Void> filter = chain.filter(serverWebExchange);
-            return filter;
+            return chain.filter(serverWebExchange);
         }
 
         return chain.filter(exchange);

--- a/src/test/java/de/rememberbrall/CustomWebFilterTest.java
+++ b/src/test/java/de/rememberbrall/CustomWebFilterTest.java
@@ -1,17 +1,19 @@
 package de.rememberbrall;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilterChain;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -27,23 +29,17 @@ public class CustomWebFilterTest extends MockitoTest {
     @Test
     public void filterForRootUrl() {
         //Given
-        MockServerHttpRequest mockServerHttpRequest = MockServerHttpRequest.options("/").build();
+        MockServerHttpRequest mockServerHttpRequest = MockServerHttpRequest.get("/").build();
         MockServerWebExchange mockServerWebExchange = MockServerWebExchange.from(mockServerHttpRequest);
 
-        ServerHttpRequest mutatedHttpRequest = mockServerWebExchange.getRequest().mutate().path("/docs/index.html").build();
-        ServerWebExchange mutatedServerWebExchange = mockServerWebExchange.mutate().request(mutatedHttpRequest).build();
-
-        when(webFilterChain.filter(mutatedServerWebExchange)).thenReturn(Mono.empty());
-
         //When
-        Mono<Void> mono = customWebFilter.filter(mockServerWebExchange, webFilterChain);
-
+        customWebFilter.filter(mockServerWebExchange, webFilterChain);
+ 
         //Then
-//        StepVerifier
-//                .create(mono)
-//                .expectNextCount(0)
-//                .verifyComplete();
-        verify(webFilterChain, atLeastOnce()).filter(mutatedServerWebExchange);
+        ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
+        verify(webFilterChain, times(2)).filter(captor.capture());
+        ServerWebExchange webExchange = captor.getValue();
+        assertThat(webExchange.getRequest().getPath().pathWithinApplication().value()).isEqualTo("/docs/index.html");
     }
 
     @Test


### PR DESCRIPTION
As org.springframework.web.server.adapter.DefaultServerWebExchange and its sub-class org.springframework.mock.web.server.MockServerWebExchange do not define hashcode() implementations, your webFilterChain.filter(mutatedServerWebExchange) could not be successful, because the principle of verifying the correct mocking of a method depends on hashcode(). If this is not defined the one of the java.lang.Object gets into action and this means referential equality, which is, of course, not the case in your test. So we have to use a cool Mockito feature called argument captor. Try to figure out how it works and read the docs here: http://static.javadoc.io/org.mockito/mockito-core/2.13.0/org/mockito/Mockito.html#15